### PR TITLE
add ability to setq, and statically define the particle color

### DIFF
--- a/power-mode.el
+++ b/power-mode.el
@@ -288,7 +288,7 @@ Set to nil to disable particle effects."
       (let ((color (foreground-color-at-point)))
         (hl-line-mode mode)
         (global-hl-line-mode global-mode)
-        color))))))
+        color)))))
 
 (defun power-mode--spawn-particles-at-point ()
   "Spawn particles at the point."

--- a/power-mode.el
+++ b/power-mode.el
@@ -84,7 +84,7 @@ Set to nil to disable shake effects."
 
 (defcustom power-mode-streak-custom-particle-color
   nil
-  "Streak particle color. If nil the foreground text color is used."
+  "User-defined streak particle color. If nil the foreground text color is used."
   :type '(choice (const nil) color)
   :group 'power)
 

--- a/power-mode.el
+++ b/power-mode.el
@@ -85,7 +85,7 @@ Set to nil to disable shake effects."
 (defcustom power-mode-streak-custom-particle-color
   nil
   "User-defined streak particle color. If nil the foreground text color is used."
-  :type '(choice (const nil) color)
+  :type '(choice color (const nil))
   :group 'power)
 
 (defcustom power-mode-streak-particle-threshold

--- a/power-mode.el
+++ b/power-mode.el
@@ -82,6 +82,12 @@ Set to nil to disable shake effects."
   :type '(choice integer (const nil))
   :group 'power)
 
+(defcustom power-mode-streak-particle-color
+  nil
+  "Streak particle color. If nil it uses the foreground text color."
+  :type 'color
+  :group 'power)
+
 (defcustom power-mode-streak-particle-threshold
   20
   "Streak required before particle effects activate.
@@ -268,6 +274,8 @@ Set to nil to disable particle effects."
 
 (defun power-mode--foreground-color-before-point ()
   "Get the foreground color of the character before the point."
+  (if power-mode-streak-particle-color
+    power-mode-streak-particle-color
   (let ((mode hl-line-mode)
         (global-mode global-hl-line-mode))
     (hl-line-mode -1)
@@ -278,7 +286,7 @@ Set to nil to disable particle effects."
       (let ((color (foreground-color-at-point)))
         (hl-line-mode mode)
         (global-hl-line-mode global-mode)
-        color))))
+        color))))))
 
 (defun power-mode--spawn-particles-at-point ()
   "Spawn particles at the point."

--- a/power-mode.el
+++ b/power-mode.el
@@ -82,7 +82,7 @@ Set to nil to disable shake effects."
   :type '(choice integer (const nil))
   :group 'power)
 
-(defcustom power-mode-streak-custom-particle-color
+(defcustom power-mode-streak-static-particle-color
   nil
   "User-defined streak particle color. If nil the foreground text color is used."
   :type '(choice color (const nil))
@@ -274,8 +274,8 @@ Set to nil to disable particle effects."
 
 (defun power-mode--foreground-color-before-point ()
   "Get the foreground color of the character before the point."
-  (if power-mode-streak-custom-particle-color
-    power-mode-streak-custom-particle-color
+  (if power-mode-streak-static-particle-color
+    power-mode-streak-static-particle-color
   (let ((mode hl-line-mode)
         (global-mode global-hl-line-mode))
     (hl-line-mode -1)

--- a/power-mode.el
+++ b/power-mode.el
@@ -84,7 +84,9 @@ Set to nil to disable shake effects."
 
 (defcustom power-mode-streak-static-particle-color
   nil
-  "User-defined streak particle color. If nil the foreground text color is used."
+  "User-defined static streak particle color.
+
+If nil, the dynamic foreground text color is used."
   :type '(choice color (const nil))
   :group 'power)
 

--- a/power-mode.el
+++ b/power-mode.el
@@ -85,7 +85,7 @@ Set to nil to disable shake effects."
 (defcustom power-mode-streak-custom-particle-color
   nil
   "Streak particle color. If nil the foreground text color is used."
-  :type '(choice (const :tag "nil " nil) color)
+  :type '(choice (const nil) color)
   :group 'power)
 
 (defcustom power-mode-streak-particle-threshold

--- a/power-mode.el
+++ b/power-mode.el
@@ -82,10 +82,10 @@ Set to nil to disable shake effects."
   :type '(choice integer (const nil))
   :group 'power)
 
-(defcustom power-mode-streak-particle-color
+(defcustom power-mode-streak-custom-particle-color
   nil
-  "Streak particle color. If nil it uses the foreground text color."
-  :type 'color
+  "Streak particle color. If nil the foreground text color is used."
+  :type '(choice (const :tag "nil " nil) color)
   :group 'power)
 
 (defcustom power-mode-streak-particle-threshold
@@ -274,8 +274,8 @@ Set to nil to disable particle effects."
 
 (defun power-mode--foreground-color-before-point ()
   "Get the foreground color of the character before the point."
-  (if power-mode-streak-particle-color
-    power-mode-streak-particle-color
+  (if power-mode-streak-custom-particle-color
+    power-mode-streak-custom-particle-color
   (let ((mode hl-line-mode)
         (global-mode global-hl-line-mode))
     (hl-line-mode -1)


### PR DESCRIPTION
Implementation for #8.
- (Uses an if statement for early-termination and return if the requisite setq exists).
- (Note: And adds an additional, missing terminating parenthesis to `power-mode--foreground-color-before-point` to make it balanced)

Behavior look to be OK, from my testing.

----
Behavior in 4 cases:

1: No setq
- uses foreground text color (the original/prior behavior)

2: Setq, valid color
- Uses valid setq color
   - `(setq power-mode-streak-particle-color "medium orchid")`

3: setq, nil
- Uses foreground text color (original behavior)

4: setq, invalid color
- Undefined Color error, which makes sense
![image](https://github.com/elizagamedev/power-mode.el/assets/7407672/4e2e1b33-1d9a-4ec2-b1f7-1d433a43d881)
